### PR TITLE
Fix AssertionError in ScheduledFutureTask

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
@@ -109,7 +109,7 @@ final class ScheduledFutureTask<V> extends PromiseTask<V> implements ScheduledFu
         // Optimization to avoid checking system clock again
         // after deadline has passed and task has been dequeued
         if (periodNanos == 0) {
-            assert nanoTime() > deadlineNanos;
+            assert nanoTime() >= deadlineNanos;
             deadlineNanos = 0L;
         }
     }


### PR DESCRIPTION
Some JVMs (like OpenJDK 8 on Windows) use a low resolution timer in System.nanoTime() and may return the same value more than once. This triggered an assertion failure when deadlineNanos was equal to nanoTime and AbstractScheduledEventExecutor#pollScheduledTask called #setConsumed.
With this change the assertion checks exactly the same condition as AbstractScheduledEventExecutor#pollScheduledTask, and will no longer fail under these circumstances.

